### PR TITLE
Removed casting from AnyObject? to Node!

### DIFF
--- a/Fiber2D/Action.swift
+++ b/Fiber2D/Action.swift
@@ -53,7 +53,7 @@ public protocol ActionModel {
      *
      *  @param target Target the action will run on.
      */
-    mutating func start(with target: AnyObject?)
+    mutating func start(with target: Node)
     
     /**
      *  Called after the action has finished.
@@ -117,7 +117,7 @@ public protocol ActionContainer: Tagged {
      *
      *  @param target Target the action will run on.
      */
-    mutating func start(with target: AnyObject?)
+    mutating func start(with target: Node)
     
     /**
      *  Called after the action has finished.
@@ -132,11 +132,11 @@ public typealias ActionContainerFiniteTime = ActionContainer & FiniteTime
 
 // Default implementation
 extension ActionModel {
-    mutating public func start(with target: AnyObject?) {}
+    mutating public func start(with target: Node) {}
     mutating public func stop() {}
     mutating func update(state: Float) {}
 }
 extension ActionContainer {
-    mutating func start(with target: AnyObject?) {}
+    mutating func start(with target: Node) {}
     mutating public func stop() {}
 }

--- a/Fiber2D/ActionConcurrent.swift
+++ b/Fiber2D/ActionConcurrent.swift
@@ -15,7 +15,7 @@ public struct ActionConcurrent: ActionModel {
 
     }
     
-    public mutating func start(with target: AnyObject?) {
+    public mutating func start(with target: Node) {
         first.start(with: target)
         second.start(with: target)
     }
@@ -48,7 +48,7 @@ public struct ActionConcurrentContainer: ActionContainer, Continous {
         }
     }
     
-    public mutating  func start(with target: AnyObject?) {
+    public mutating func start(with target: Node) {
         elapsed = 0
         first.start(with: target)
         second.start(with: target)

--- a/Fiber2D/ActionContinous.swift
+++ b/Fiber2D/ActionContinous.swift
@@ -13,7 +13,7 @@ public struct ActionContinousContainer: ActionContainer, Continous {
         action.update(state: state)
     }
     
-    public mutating  func start(with target: AnyObject?) {
+    public mutating func start(with target: Node) {
         elapsed = 0
         action.start(with: target)
     }

--- a/Fiber2D/ActionEase.swift
+++ b/Fiber2D/ActionEase.swift
@@ -32,7 +32,7 @@ public struct ActionEaseContainer: ActionContainer, Continous {
         action.update(state: easeBlock(state))
     }
     
-    public mutating func start(with target: AnyObject?) {
+    public mutating func start(with target: Node) {
         elapsed = 0
         action.start(with: target)
     }
@@ -51,7 +51,7 @@ public struct ActionEaseContainer: ActionContainer, Continous {
         )
     }
     
-    weak var target: AnyObject? = nil
+    weak var target: Node?
     public var tag: Int = 0
     public let duration: Time
     private(set) public var elapsed:  Time = 0.0

--- a/Fiber2D/ActionInstant+Node.swift
+++ b/Fiber2D/ActionInstant+Node.swift
@@ -64,8 +64,8 @@ public struct ActionHide: ActionModel {
     public var target: Node!
     
     public init() { }
-    public mutating func start(with target: AnyObject?) {
-        self.target = target as! Node
+    public mutating func start(with target: Node) {
+        self.target = target
     }
     public mutating func update(state: Float) {
         target.visible = false
@@ -81,8 +81,8 @@ public struct ActionShow: ActionModel {
     public var target: Node!
     
     public init() { }
-    public mutating func start(with target: AnyObject?) {
-        self.target = target as! Node
+    public mutating func start(with target: Node) {
+        self.target = target
     }
     public mutating func update(state: Float) {
         target.visible = true
@@ -98,8 +98,8 @@ public struct ActionToggleVisibility: ActionModel {
     public var target: Node!
     
     public init() { }
-    public mutating func start(with target: AnyObject?) {
-        self.target = target as! Node
+    public mutating func start(with target: Node) {
+        self.target = target
     }
     public mutating func update(state: Float) {
         target.visible = !target.visible
@@ -114,8 +114,8 @@ public struct ActionRemove: ActionModel {
     public var target: Node!
     
     public init() { }
-    public mutating func start(with target: AnyObject?) {
-        self.target = target as! Node
+    public mutating func start(with target: Node) {
+        self.target = target
     }
     public mutating func update(state: Float) {
         target.removeFromParent()

--- a/Fiber2D/ActionInstant.swift
+++ b/Fiber2D/ActionInstant.swift
@@ -13,7 +13,7 @@ public struct ActionInstantContainer: ActionContainer {
         action.update(state: 1.0)
     }
     
-    mutating public func start(with target: AnyObject?) {
+    mutating public func start(with target: Node) {
         action.start(with: target)
     }
     

--- a/Fiber2D/ActionRepeat.swift
+++ b/Fiber2D/ActionRepeat.swift
@@ -18,7 +18,7 @@ import SwiftMath
 public struct ActionRepeatForeverContainer: ActionContainer {
     public mutating func update(state: Float) { }
     
-    public mutating func start(with target: AnyObject?) {
+    public mutating func start(with target: Node) {
         self.target = target
         innerContainer.start(with: target)
     }
@@ -37,12 +37,14 @@ public struct ActionRepeatForeverContainer: ActionContainer {
                 }
             }
             
-            innerContainer.start(with: target)
+            if let target = target {
+                innerContainer.start(with: target)
+            }
         }
     }
     
     public var tag: Int = 0
-    weak var target: AnyObject? = nil
+    weak var target: Node?
     public var isDone: Bool {
         return false
     }
@@ -68,7 +70,9 @@ public struct ActionRepeatContainer: ActionContainer, FiniteTime {
                 remainingRepeats -= 1
                 
                 innerContainer.stop()
-                innerContainer.start(with: target)
+                if let target = target {
+                    innerContainer.start(with: target)
+                }
                 self.nextDt = Float(Int(repeatCount - remainingRepeats) + 1) / Float(repeatCount)
             }
             // fix for issue #1288, incorrect end value of repeat
@@ -96,7 +100,7 @@ public struct ActionRepeatContainer: ActionContainer, FiniteTime {
         
     }
     
-    public mutating  func start(with target: AnyObject?) {
+    public mutating func start(with target: Node) {
         self.elapsed = 0
         self.target = target
         self.remainingRepeats = repeatCount
@@ -106,7 +110,9 @@ public struct ActionRepeatContainer: ActionContainer, FiniteTime {
 
     mutating public func step(dt: Time) {
         guard icDuration > 0 else {
-            innerContainer.start(with: target)
+            if let target = target {
+                innerContainer.start(with: target)
+            }
             innerContainer.update(state: 1.0)
             innerContainer.stop()
             remainingRepeats -= 1
@@ -121,7 +127,7 @@ public struct ActionRepeatContainer: ActionContainer, FiniteTime {
     }
     
     public var tag: Int = 0
-    weak var target: AnyObject? = nil
+    weak var target: Node?
     public var isDone: Bool {
         return remainingRepeats == 0
     }

--- a/Fiber2D/ActionRepeat.swift
+++ b/Fiber2D/ActionRepeat.swift
@@ -37,14 +37,12 @@ public struct ActionRepeatForeverContainer: ActionContainer {
                 }
             }
             
-            if let target = target {
-                innerContainer.start(with: target)
-            }
+            innerContainer.start(with: target)
         }
     }
     
     public var tag: Int = 0
-    weak var target: Node?
+    weak var target: Node!
     public var isDone: Bool {
         return false
     }
@@ -70,9 +68,7 @@ public struct ActionRepeatContainer: ActionContainer, FiniteTime {
                 remainingRepeats -= 1
                 
                 innerContainer.stop()
-                if let target = target {
-                    innerContainer.start(with: target)
-                }
+                innerContainer.start(with: target)
                 self.nextDt = Float(Int(repeatCount - remainingRepeats) + 1) / Float(repeatCount)
             }
             // fix for issue #1288, incorrect end value of repeat
@@ -109,7 +105,6 @@ public struct ActionRepeatContainer: ActionContainer, FiniteTime {
     }
 
     mutating public func step(dt: Time) {
-        guard let target = target else { return }
         guard icDuration > 0 else {
             innerContainer.start(with: target)
             innerContainer.update(state: 1.0)
@@ -126,7 +121,7 @@ public struct ActionRepeatContainer: ActionContainer, FiniteTime {
     }
     
     public var tag: Int = 0
-    weak var target: Node?
+    weak var target: Node!
     public var isDone: Bool {
         return remainingRepeats == 0
     }

--- a/Fiber2D/ActionRepeat.swift
+++ b/Fiber2D/ActionRepeat.swift
@@ -109,10 +109,9 @@ public struct ActionRepeatContainer: ActionContainer, FiniteTime {
     }
 
     mutating public func step(dt: Time) {
+        guard let target = target else { return }
         guard icDuration > 0 else {
-            if let target = target {
-                innerContainer.start(with: target)
-            }
+            innerContainer.start(with: target)
             innerContainer.update(state: 1.0)
             innerContainer.stop()
             remainingRepeats -= 1

--- a/Fiber2D/ActionRewind.swift
+++ b/Fiber2D/ActionRewind.swift
@@ -18,7 +18,7 @@ public struct ActionRewindContainer: ActionContainer, Continous {
         action.update(state: 1.0 - state)
     }
     
-    public mutating  func start(with target: AnyObject?) {
+    public mutating func start(with target: Node) {
         elapsed = 0
         action.start(with: target)
     }

--- a/Fiber2D/ActionSequence.swift
+++ b/Fiber2D/ActionSequence.swift
@@ -60,8 +60,7 @@ public struct ActionSequenceContainer: ActionContainer, Continous {
             return
         }
         // New action. Start it.
-        if found != last,
-            let target = target {
+        if found != last {
             actions[found].start(with: target)
         }
         actions[found].update(state: new_t)

--- a/Fiber2D/ActionSequence.swift
+++ b/Fiber2D/ActionSequence.swift
@@ -9,7 +9,6 @@
 public struct ActionSequenceContainer: ActionContainer, Continous {
     @inline(__always)
     mutating public func update(state: Float) {
-        guard let target = target else { return }
         let t = state
         var found = 0
         var new_t: Float = 0.0
@@ -92,10 +91,10 @@ public struct ActionSequenceContainer: ActionContainer, Continous {
         )
     }
     
-    weak var target: Node?
+    weak var target: Node!
     public var tag: Int = 0
     private(set) public var duration: Time = 0.0
-    private(set) public var elapsed:  Time = 0.0
+    private(set) public var elapsed: Time = 0.0
     
     public var isDone: Bool {
         return elapsed > duration

--- a/Fiber2D/ActionSequence.swift
+++ b/Fiber2D/ActionSequence.swift
@@ -9,6 +9,7 @@
 public struct ActionSequenceContainer: ActionContainer, Continous {
     @inline(__always)
     mutating public func update(state: Float) {
+        guard let target = target else { return }
         let t = state
         var found = 0
         var new_t: Float = 0.0
@@ -35,9 +36,7 @@ public struct ActionSequenceContainer: ActionContainer, Continous {
         if found == 1 {
             if last == -1 {
                 // action[0] was skipped, execute it.
-                if let target = target {
-                    actions[0].start(with: target)
-                }
+                actions[0].start(with: target)
                 actions[0].update(state: 1.0)
                 actions[0].stop()
             }

--- a/Fiber2D/ActionSequence.swift
+++ b/Fiber2D/ActionSequence.swift
@@ -35,7 +35,9 @@ public struct ActionSequenceContainer: ActionContainer, Continous {
         if found == 1 {
             if last == -1 {
                 // action[0] was skipped, execute it.
-                actions[0].start(with: target)
+                if let target = target {
+                    actions[0].start(with: target)
+                }
                 actions[0].update(state: 1.0)
                 actions[0].stop()
             }
@@ -59,14 +61,15 @@ public struct ActionSequenceContainer: ActionContainer, Continous {
             return
         }
         // New action. Start it.
-        if found != last {
+        if found != last,
+            let target = target {
             actions[found].start(with: target)
         }
         actions[found].update(state: new_t)
         self.last = found
     }
     
-    public mutating func start(with target: AnyObject?) {
+    public mutating func start(with target: Node) {
         elapsed = 0
         self.target = target
         self.split = actions[0].duration / max(duration, Float.ulpOfOne)
@@ -91,7 +94,7 @@ public struct ActionSequenceContainer: ActionContainer, Continous {
         )
     }
     
-    weak var target: AnyObject? = nil
+    weak var target: Node?
     public var tag: Int = 0
     private(set) public var duration: Time = 0.0
     private(set) public var elapsed:  Time = 0.0

--- a/Fiber2D/ActionSpeed.swift
+++ b/Fiber2D/ActionSpeed.swift
@@ -12,7 +12,7 @@ public struct ActionSpeedContainer: ActionContainer, Continous {
         action.update(state: state)
     }
     
-    public mutating  func start(with target: AnyObject?) {
+    public mutating func start(with target: Node) {
         elapsed = 0
         self.target = target
         action.start(with: target)
@@ -31,7 +31,7 @@ public struct ActionSpeedContainer: ActionContainer, Continous {
         )
     }
     
-    weak var target: AnyObject? = nil
+    weak var target: Node?
     public var tag: Int = 0
     public let speed: Float
     public let duration: Time

--- a/Fiber2D/ActionTransform.swift
+++ b/Fiber2D/ActionTransform.swift
@@ -37,8 +37,7 @@ struct ActionRotateTo: ActionModel {
         simple = aX == aY
     }
 
-    mutating func start(with target: AnyObject?) {
-        let target = target as! Node
+    mutating func start(with target: Node) {
         self.target = target
         // Simple Rotation
         if simple {
@@ -119,8 +118,7 @@ struct ActionRotateBy: ActionModel {
         rotateY = aY != nil
     }
     
-    mutating func start(with target: AnyObject?) {
-        let target = target as! Node
+    mutating func start(with target: Node) {
         self.target = target
         self.startAngleX = target.rotationalSkewX
         self.startAngleY = target.rotationalSkewY
@@ -170,9 +168,8 @@ struct ActionSkewTo: ActionModel {
         self.endSkewY = sy
     }
     
-    mutating func start(with target: AnyObject?) {
-        self.target = target as! Node
-        let target = self.target!
+    mutating func start(with target: Node) {
+        self.target = target
         
         // X
         self.startSkewX = target.skewX
@@ -228,10 +225,8 @@ struct ActionSkewBy: ActionModel {
         self.deltaY = sy
     }
     
-    mutating func start(with target: AnyObject?) {
-        self.target = target as! Node
-        let target = self.target!
-        
+    mutating func start(with target: Node) {
+        self.target = target
         self.startSkewX = target.skewX
         self.startSkewY = target.skewY
     }
@@ -265,10 +260,8 @@ struct ActionMoveTo: ActionModel {
         endPosition = p
     }
     
-    mutating func start(with target: AnyObject?) {
-        self.target = target as! Node
-        let target = self.target!
-        
+    mutating func start(with target: Node) {
+        self.target = target
         self.startPosition = target.position
     }
     
@@ -303,10 +296,8 @@ struct ActionMoveBy: ActionModel {
         deltaPosition = p
     }
     
-    mutating func start(with target: AnyObject?) {
-        self.target = target as! Node
-        let target = self.target!
-        
+    mutating func start(with target: Node) {
+        self.target = target
         self.startPosition = target.position
         #if ENABLE_STACKABLE_ACTIONS
         self.previousPosition = startPosition


### PR DESCRIPTION
Please review the following changes.
This is mainly to remove all the nasty objective-c id to CCNode casting.